### PR TITLE
Proper treatment of the enter Key

### DIFF
--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -121,7 +121,7 @@ int lets_tab_builtin(char **args)
         length++;
       }
     }
-    if (c == 10 || c == 11 || c == 13 || c == 32) {
+    if (c == 32 || c == 10 || c == 11 || c == 13) {
       length = 0;
       word = NULL;
     }

--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -115,12 +115,13 @@ int lets_tab_builtin(char **args)
     // Doesn't print tab, bkspace, or del
     if (c != 9 && c != 127 && c != 8) {
       printw("%c", c);
-      word = ll_new(word);
-      word->letter = c;
-      length++;
+      if (c != 10 && c != 11 && c != 13) {
+        word = ll_new(word);
+        word->letter = c;
+        length++;
+      }
     }
-
-    if (c == 32) {
+    if (c == 10 || c == 11 || c == 13 || c == 32) {
       length = 0;
       word = NULL;
     }


### PR DESCRIPTION
Adds the enter key to the Interactive mode interface, so that it's printed but not added to the word.