### PR TITLE
Basic save file functionality

### DIFF
--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -6,7 +6,6 @@ Program which implements a tab-based command
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <string.h>
 #include "minishell.h"
 #include "ll.h"
 #include "batch_mode.h"
@@ -163,6 +162,7 @@ int lets_tab_builtin(char **args)
   int length = 0;
   int total_length = 0;
   int c;
+  int x, y;
   initscr();    // Start Curses Mode
   cbreak();
   noecho();
@@ -220,7 +220,6 @@ int lets_tab_builtin(char **args)
      */
 
     if (c == 127 || c == 8) {
-        int x, y;
         getyx(stdscr, y, x);
         x--;
         move(y, x);
@@ -239,35 +238,36 @@ int lets_tab_builtin(char **args)
           length = 0;
     }
 
-    // Right now, '`' saves the file
+    // Pressing '`' saves the file to the screen
     if (c == 96) {
-      printw("saving the screen to autocomplete.txt");
-      total_length++;
-      char *screen = malloc(sizeof(char)*(total_length));
+      getyx(stdscr, y, x);
+      printw("\nsaving the screen to autocomplete.txt\n");
+      char screen[total_length];
       int j = total_length;
       struct word *tmp;
       for (tmp = word; tmp != NULL; tmp = ll_next(tmp)) {
         screen[j] = tmp->letter;
         j--;
       }
-      int k = 0;
-      printw("screen:\n");
-      for (k = 0; k <= total_length; k++) {
-        printw("%c", screen[k]);
-      }
       printw("\n");
       FILE *fp = fopen("autocomplete_save.txt", "w");
-      printw("total length: %d", total_length);
+      printw("characters in file (including spaces): %d\n", total_length); //If you take this out, it seg faults
       if (fp) {
-        j = 0;
-        fprintf(fp, "%c", screen[j]);
-        for (j = 0; j <= total_length; j++) {
+        for (j = 1; j <= total_length; j++) {
           fprintf(fp, "%c", screen[j]);
         }
       }
       else
         printw("could not open file");
       fclose(fp);
+      printw("press enter to continue");
+      int c_0;
+      while (10 != (c_0 = getch()))
+        ;
+      move(y, x);
+      refresh();
+      clrtobot();
+      refresh();
     }
 
     cbreak();

--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -238,7 +238,7 @@ int lets_tab_builtin(char **args)
           length = 0;
     }
 
-    // Pressing '`' saves the file to the screen
+    // Pressing '`' saves the screen to a file
     if (c == 96) {
       getyx(stdscr, y, x);
       printw("\nsaving the screen to autocomplete.txt\n");


### PR DESCRIPTION
Adds a feature to interactive mode. If you press '`', then it saves the screen to a file autocomplete_save.txt. 

Limitations:
- This means you can't type the '`' key in the document, but that shouldn't matter. I chose this design because we already use '~' to close interactive mode, so I figured keeping save/close on the same key would be a good idea.
- You cannot change the name of the file you're saving to, so autocomplete_save will just get overwritten each time. I'll be making a new issue/pull request for that, to be completed later this sprint (@lydiafilipe, if I should hold off on the pr until then, let me know).