### PR TITLE
Adds prompt to the beginning of interactive mode

### DIFF
--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -171,7 +171,7 @@ int lets_tab_builtin(char **args)
     printw("Welcome to the interactive autocomplete editor!\n");
     printw("While typing a word, press tab to display autocomplete possibilities.\n");
     printw("If you want to save your work to a text file, press ` .\n");
-    printw("Press enter to begin!");
+    printw("To exit interactive mode, press ~ . Press enter to begin!");
     int c_start;
     while (10 != (c_start = getch())) 
       ;

--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -293,15 +293,13 @@ int lets_tab_builtin(char **args)
         screen[j] = tmp->letter;
         j--;
       }
-      printw("\n"); //If you take this line out, it seg faults
       FILE *fp = fopen(complete_filename, "w");
-      printw("characters in file (including spaces): %d\n", total_length); //If you take this line out, it seg faults
       if (fp) {
         for (j = 1; j <= total_length; j++) {
           fprintf(fp, "%c", screen[j]);
         }
          fclose(fp);
-        printw("press enter to continue");
+        printw("\nfile save successful! press enter to continue");
         int c_1;
         while (10 != (c_1 = getch()))
           ;

--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -161,13 +161,25 @@ int lets_tab_builtin(char **args)
 
   int length = 0;
   int total_length = 0;
+  int start = 0;
   int c;
   int x, y;
   initscr();    // Start Curses Mode
   cbreak();
   noecho();
-  while('~' != (c = getch())) {
+  if (start == 0) {
+    printw("Welcome to the interactive autocomplete editor!\n");
+    printw("While typing a word, press tab to display autocomplete possibilities.\n");
+    printw("If you want to save your work to a text file, press ` .\n");
+    printw("Press enter to begin!");
+    int c_start;
+    while (10 != (c_start = getch())) 
+      ;
+    clear();
+    start = 1;
+  }
 
+  while('~' != (c = getch())) {
     // Doesn't print tab, bkspace, or del
     if (c != 9 && c != 127 && c != 8 && c != 96) {
       printw("%c", c);
@@ -208,16 +220,6 @@ int lets_tab_builtin(char **args)
         total_length++;
       }
     }
-
-    /* Jonas 05.16: Implement delete key
-     * Known bug: as of right now, we can only
-     * delete one word at a time - the linked
-     * list only stores one word at a time, so
-     * therefore we cannot access the prior word
-     * after deleting the most recently typed one.
-     * We'll have to change the word storage mechanism,
-     * so I'm leaving that to Sprint 4
-     */
 
     if (c == 127 || c == 8) {
         getyx(stdscr, y, x);

--- a/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
+++ b/autocomplete_interactive/autocomplete_shell/src/lets_tab.c
@@ -308,6 +308,7 @@ int lets_tab_builtin(char **args)
         clrtobot();
         refresh();
       }
+      
       else
         printw("could not open file, saving aborted");
     }


### PR DESCRIPTION
Adds a prompt with the following message to the beginning of interactive mode:

Welcome to the interactive autocomplete editor!
While typing a word, press tab to display autocomplete possibilities.
If you want to save your work to a text file, press ` .
Press enter to begin!

After the user presses "enter", the screen is cleared and interactive mode begins.

Also, I fixed the bug where if you removed a particular print statement, it segfaulted! (see pull request #96)